### PR TITLE
updated pr template to have closes: keyword

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,9 @@
 A brief summary of the changes.
 
 ## Closes issues
-#1 (change the number)
+Closes: #1 (change the number)
+Closes: #2
+...
 
 ## Changes
 - List the main changes here.


### PR DESCRIPTION
## Description
PR template now has 'Closes:' before issue numbers to link them to issues on the project board
## Closes issues
Closes: #63 
## Changes
- modified `pull_request_template.md`
## Checklist
- [x] Code works as expected
