### PR TITLE
[fix] ETL pipeline not creating data folder

### DIFF
--- a/source/pipeline/pipeline.py
+++ b/source/pipeline/pipeline.py
@@ -10,19 +10,19 @@ def lambda_handler(event, context):
     try:
         extract_gog()
     except Exception as e:
-        return {'status': 'error', 'msg': f'{str(e)} occured in extract_gog'}
+        return {'status': 'error', 'msg': f'{str(e)} occurred in extract_gog'}
     try:
         export_steam()
     except Exception as e:
-        return {'status': 'error', 'msg': f'{str(e)} occured in extract_steam'}
+        return {'status': 'error', 'msg': f'{str(e)} occurred in extract_steam'}
     try:
         transform_all()
     except Exception as e:
-        return {'status': 'error', 'msg': f'{str(e)} occured in transform'}
+        return {'status': 'error', 'msg': f'{str(e)} occurred in transform'}
     try:
         load_data()
     except Exception as e:
-        return {'status': 'error', 'msg': f'{str(e)} occured in load'}
+        return {'status': 'error', 'msg': f'{str(e)} occurred in load'}
 
     return {'status': 'success', 'msg': 'RDS updated, pipeline successfully run'}
 


### PR DESCRIPTION
## Description
The ETL pipeline script was not runnning due to the data/ folder not being found. This PR fixed that issue
## Closes issues
Closes: #93
## Changes
- Modified Dockerfile to create the data/ directory directly in tmp/
- Removed `os.path.exists` statements which were falsely raising errors 

## Checklist
- [x] Code works as expected
